### PR TITLE
add confirm dialog when directories already exist

### DIFF
--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -363,7 +363,7 @@ class HSHandler(IPythonHandler):
         overwrite = self.get_argument('overwrite', 0)
         goto = self.get_argument('goto', 0)
 
-        print('GET', id , start, app, overwrite, goto)
+        self.log.info('GET %s %s %s %s %s' % (id , start, app, overwrite, goto))
 
         # create Downloads directory if necessary
         download_dir = os.environ.get('JUPYTER_DOWNLOADS', 'Downloads')

--- a/nbfetch/templates/confirm.html
+++ b/nbfetch/templates/confirm.html
@@ -1,0 +1,62 @@
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+      integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
+      integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+
+  </head>
+  <body>
+    <div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-labelledby="confirmModalLabel"
+    aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="confirmModalLabel">Overwrite Existing Directory?</h5>
+        </div>
+        <div class="modal-body">
+          Directory "{{directory}}" already exists.  
+          <br><br>
+          Do you want to simply go to the current directory or 
+          do you want to overwrite the current contents, possibly erasing any changes you have made?
+        </div>
+        <div class="modal-footer">
+          <button id="overwrite" class="btn btn-danger" data-dismiss="modal">Overwrite</button>
+          <button id="goto" class="btn btn-primary" data-dismiss="modal">Go to Directory</button>
+        </div>
+      </div>
+    </div>
+    </div>
+    <script> $(function () { 
+      console.log('starting modal dialog');
+      $('#confirmModal').modal({keyboard: false, backdrop: 'static'});
+      
+      $('#confirmModal').on('keypress', function (event) {
+        // enter key goes to the existing code
+        var keycode = (event.keyCode ? event.keyCode : event.which);
+        if (keycode == '13') {
+          window.location.replace(window.location.href + '&goto=1');
+        }
+      });
+
+      $('#confirmModal').on('hide.bs.modal', function (e) {
+        // get the id of the button that was clicked
+        var res = $(document.activeElement).attr('id');
+        // redirect to calling url with "goto" or "overwrite" parameter
+        window.location.replace(window.location.href + '&' + res + '=1');
+      });
+    });
+    </script>
+  </body>
+</html>
+
+

--- a/nbfetch/templates/confirm.html
+++ b/nbfetch/templates/confirm.html
@@ -21,13 +21,13 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="confirmModalLabel">Overwrite Existing Directory?</h5>
+          <h5 class="modal-title" id="confirmModalLabel">Directory Exists</h5>
         </div>
         <div class="modal-body">
-          Directory "{{directory}}" already exists.  
+          Directory "{{directory}}" already exists on JupyterHub.
           <br><br>
-          Do you want to simply go to the current directory or 
-          do you want to overwrite the current contents, possibly erasing any changes you have made?
+          Do you want to overwrite the current contents, replacing it with files from HydroShare?
+          Or just go to the current directory on JupyterHub?
         </div>
         <div class="modal-footer">
           <button id="overwrite" class="btn btn-danger" data-dismiss="modal">Overwrite</button>


### PR DESCRIPTION
In handlers.py:HSHander.get(), I removed an unused argument, then added 'overwrite' and 'goto'.
I did this so links can be created to force overwrite or not. For example,
"http://hostname/hs-pull?id=8caa62c46c424a818899ebeca6f30a83&start=mynb.ipynb?overwrite=1"
Not sure if this will be useful, but it also simplified the logic for the dialog...

In get(), if the resource directory exists and neither overwrite or goto is set, then a bootstrap modal dialog pops up.  User must select an option or hit the enter key(which does a 'goto').  There is no other way to exit the dialog.  Selecting an option simply adds that option to the query string and reloads.  This time, overwrite or goto is set and the dialog is not displayed.

I'm not an expert as Javascript or Tornado, so it is entirely possible there are improvements to be made.
