### PR TITLE
Fix template rendering bug

### DIFF
--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -14,6 +14,8 @@ from .version import __version__
 from notebook.utils import url_path_join
 import pickle
 
+JINJA2_ENV_KEY = "notebook_jinja2_env"
+
 class HSLoginHandler(IPythonHandler):
     @gen.coroutine
     def get(self):
@@ -232,7 +234,7 @@ class UIHandler(IPythonHandler):
         # FIXME: Is this really the best way to use jinja2 here?
         # I can't seem to get the jinja2 env in the base handler to
         # actually load templates from arbitrary paths ugh.
-        jinja2_env = self.settings['jinja2_env']
+        jinja2_env = self.settings[JINJA2_ENV_KEY]
         jinja2_env.loader = jinja2.ChoiceLoader([
             jinja2_env.loader,
             jinja2.FileSystemLoader(
@@ -275,7 +277,7 @@ class UIHandler(IPythonHandler):
 class HSHandler(IPythonHandler):
     def initialize(self):
         super().initialize()
-        jinja2_env = self.settings['jinja2_env']
+        jinja2_env = self.settings[JINJA2_ENV_KEY]
         jinja2_env.loader = jinja2.ChoiceLoader([
             jinja2_env.loader,
             jinja2.FileSystemLoader(

--- a/nbfetch/version.py
+++ b/nbfetch/version.py
@@ -1,2 +1,2 @@
 """"The nbfetch PyPI package SemVer version."""
-__version__ = '0.0.3'
+__version__ = '0.0.4'

--- a/setup.py
+++ b/setup.py
@@ -3,39 +3,39 @@ from distutils.util import convert_path
 
 # Imports __version__, reference: https://stackoverflow.com/a/24517154/2220152
 ns = {}
-ver_path = convert_path('nbfetch/version.py')
+ver_path = convert_path("nbfetch/version.py")
 with open(ver_path) as ver_file:
     exec(ver_file.read(), ns)
-__version__ = ns['__version__']
+__version__ = ns["__version__"]
 
 setup(
-    name='nbfetch',
+    name="nbfetch",
     version=__version__,
-    url='',
-    license='3-clause BSD',
-    author='Peter Veerman, YuviPanda',
-    author_email='peterkangveerman@gmail.com',
-    description='Notebook Extension to do one-way synchronization of git repositories',
+    url="",
+    license="3-clause BSD",
+    author="Peter Veerman, YuviPanda",
+    author_email="peterkangveerman@gmail.com",
+    description="Notebook Extension to do one-way synchronization of git repositories",
     packages=find_packages(),
     include_package_data=True,
-    platforms='any',
-    install_requires=['notebook>=5.5.0', 'tornado'],
+    platforms="any",
+    install_requires=["notebook>=5.5.0", "tornado", "hs_restclient"],
     data_files=[
-        ('etc/jupyter/jupyter_notebook_config.d', ['nbfetch/etc/nbfetch.json'])
+        ("etc/jupyter/jupyter_notebook_config.d", ["nbfetch/etc/nbfetch.json"])
     ],
     zip_safe=False,
     entry_points={
-        'console_scripts': [
-            'nbfetch = nbfetch.pull:main',
+        "console_scripts": [
+            "nbfetch = nbfetch.pull:main",
         ],
     },
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: POSIX',
-        'Operating System :: MacOS',
-        'Operating System :: Unix',
-        'Programming Language :: Python :: 3',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ]
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: POSIX",
+        "Operating System :: MacOS",
+        "Operating System :: Unix",
+        "Programming Language :: Python :: 3",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
 )


### PR DESCRIPTION
[`nbclassic`](https://github.com/jupyterlab/nbclassic/pull/77) changed the tornado setting key used for storing `jinja2.Environment` objects in [nbclassic #77](https://github.com/jupyterlab/nbclassic/pull/77). As a result, this causes handlers that render templates to raise a `TemplateNotFound` error. This PR resolves this issue. 