### PR TITLE
nbfetch templates not rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,17 @@
+# python
 *.pyc
-
 dist/
 build/
 *.egg-info/
-
 .tox/
 .coverage
 
+# osx
 .DS_Store
-.cache/
-data8assets/
-.autopull_list
-summer/
-test-repo/
+
+# ignore vscode
+.vscode/
+
+# python virtual env
+env/
+venv/

--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ with automatic conflict resolution.
 
 Pull Hydroshare resources to a local directory.
 
-# Installation
+## Installation
 
-You can install nbgitpuller from PyPI.
+```shell
+# install
+pip install -U --no-cache-dir --upgrade-strategy only-if-needed git+https://github.com/hydroshare/nbfetch
 
-    pip install -U --no-cache-dir --upgrade-strategy only-if-needed git+https://github.com/hydroshare/nbfetch
+# enable jupyter_server extension
+jupyter server extension enable --py nbfetch
+```
 
-You can then enable the serverextension
-
-    jupyter serverextension enable --py nbfetch --sys-prefix
-
-# Usage
+## Usage
 
 See https://github.com/jupyterhub/nbgitpuller.
 

--- a/README.md
+++ b/README.md
@@ -32,3 +32,48 @@ Example on a local Jupyter installation.
 On JupyterHub,
 
   https://jupyterhub-dev.uwrl.usu.edu/hub/user-redirect/hs-pull?id=8caa62c46c424a818899ebeca6f30a83&start=spiro3D.ipynb
+
+## Development
+
+Setup development environment
+
+```
+# clone git repo
+git clone git@github.com:hydroshare/nbfetch.git && cd nbfetch
+
+# create and activate python environment
+python3 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+
+# install nbfetch in edit mode
+pip install -e .
+
+# enable jupyter_server extension
+jupyter server extension enable --py nbfetch
+
+# start jupyter lab
+jupyter lab
+```
+
+`nbfetch` requires HydroShare user authentication (username, password) or authorization (OAuth2) to
+function. HydroShare user authentication can be provided in two ways, by file or via environment
+variables (see below). At this time, we do not have guidance for supplying using authorization
+(OAuth2) in a development environment.
+
+### Authentication Locations
+
+HydroShare user authentication can be provided using either files or environment variables.
+`nbfetch` will look for authentication information in the following locations:
+
+Note: files take precedence over environment variables
+
+file locations:
+
+- `~/.hs_user`
+- `~/.hs_pass`
+
+environment variables:
+
+- `HS_USER`
+- `HS_PASS`

--- a/jupyter-config/jupyter_server_config.d/nbfetch.json
+++ b/jupyter-config/jupyter_server_config.d/nbfetch.json
@@ -1,0 +1,7 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "nbfetch": true
+        }
+    }
+}

--- a/nbfetch/__init__.py
+++ b/nbfetch/__init__.py
@@ -18,7 +18,7 @@ HERE = os.path.dirname(__file__)
 class NbFetchApp(ExtensionApp):
     # Name of the extension.
     name = "nbfetch"
-    default_url = "/"
+    default_url = "/nbfetch"
     load_other_extensions = True
     file_url_prefix = "/"
 
@@ -53,17 +53,18 @@ class NbFetchApp(ExtensionApp):
 
     def initialize_handlers(self):
         # Add a group with () to send to handler.
-        base_url = url_path_join(self.settings["base_url"], "git-pull")
-        hs_url = url_path_join(self.settings["base_url"], "hs-pull")
+        base_url = r"/nbfetch"
+        git_url = url_path_join(base_url, "git-pull")
+        hs_url = url_path_join(base_url, "hs-pull")
 
         self.handlers.extend(
             [
-                (url_path_join(base_url, "api"), SyncHandler),
+                (url_path_join(git_url, "api"), SyncHandler),
                 (url_path_join(hs_url, "api"), HSyncHandler),
-                (base_url, UIHandler),
+                (git_url, UIHandler),
                 (hs_url, HSHandler),
                 (
-                    url_path_join(base_url, "static", "(.*)"),
+                    url_path_join(git_url, "static", "(.*)"),
                     StaticFileHandler,
                     {"path": os.path.join(HERE, "static")},
                 ),
@@ -73,7 +74,7 @@ class NbFetchApp(ExtensionApp):
                     {"path": os.path.join(HERE, "static")},
                 ),
                 (
-                    url_path_join(self.settings["base_url"], "hslogin"),
+                    url_path_join(base_url, "hslogin"),
                     HSLoginHandler,
                 ),
             ]

--- a/nbfetch/__init__.py
+++ b/nbfetch/__init__.py
@@ -5,32 +5,80 @@ from notebook.utils import url_path_join
 from tornado.web import StaticFileHandler
 import os
 
+import jupyter_server
+from jupyter_server.extension.application import ExtensionApp
+from notebook import DEFAULT_STATIC_FILES_PATH, DEFAULT_TEMPLATE_PATH_LIST
+import jinja2
+import gettext
+
+
+HERE = os.path.dirname(__file__)
+
+
+class NbFetchApp(ExtensionApp):
+    # Name of the extension.
+    name = "nbfetch"
+    default_url = "/"
+    load_other_extensions = True
+    file_url_prefix = "/"
+
+    # Local path to static files directory.
+    static_paths = [
+        os.path.join(HERE, "static"),
+        DEFAULT_STATIC_FILES_PATH,
+    ]
+
+    def initialize_templates(self):
+        template_paths = [os.path.join(HERE, "templates"), *DEFAULT_TEMPLATE_PATH_LIST]
+
+        self.settings.update({f"{self.name}_template_paths": template_paths})
+
+        self.jinja2_env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(template_paths),
+            extensions=["jinja2.ext.i18n"],
+            autoescape=True,
+        )
+
+        base_dir = os.path.realpath(os.path.join(jupyter_server.__file__, "..", ".."))
+        nbui = gettext.translation(
+            "nbui",
+            localedir=os.path.join(base_dir, "jupyter_server/i18n"),
+            fallback=True,
+        )
+
+        self.jinja2_env.install_gettext_translations(nbui, newstyle=False)
+
+        # Add the jinja2 environment for this extension to the tornado settings.
+        self.settings.update({f"{self.name}_jinja2_env": self.jinja2_env})
+
+    def initialize_handlers(self):
+        # Add a group with () to send to handler.
+        base_url = url_path_join(self.settings["base_url"], "git-pull")
+        hs_url = url_path_join(self.settings["base_url"], "hs-pull")
+
+        self.handlers.extend(
+            [
+                (url_path_join(base_url, "api"), SyncHandler),
+                (url_path_join(hs_url, "api"), HSyncHandler),
+                (base_url, UIHandler),
+                (hs_url, HSHandler),
+                (
+                    url_path_join(base_url, "static", "(.*)"),
+                    StaticFileHandler,
+                    {"path": os.path.join(HERE, "static")},
+                ),
+                (
+                    url_path_join(hs_url, "static", "(.*)"),
+                    StaticFileHandler,
+                    {"path": os.path.join(HERE, "static")},
+                ),
+                (
+                    url_path_join(self.settings["base_url"], "hslogin"),
+                    HSLoginHandler,
+                ),
+            ]
+        )
+
 
 def _jupyter_server_extension_paths():
-    return [{
-        'module': 'nbfetch',
-    }]
-
-
-def load_jupyter_server_extension(nbapp):
-    web_app = nbapp.web_app
-    base_url = url_path_join(web_app.settings['base_url'], 'git-pull')
-    hs_url = url_path_join(web_app.settings['base_url'], 'hs-pull')
-    handlers = [
-        (url_path_join(base_url, 'api'), SyncHandler),
-        (url_path_join(hs_url, 'api'), HSyncHandler),
-        (base_url, UIHandler),
-        (hs_url, HSHandler),
-        (
-            url_path_join(base_url, 'static', '(.*)'),
-            StaticFileHandler,
-            {'path': os.path.join(os.path.dirname(__file__), 'static')}
-        ),
-        (
-            url_path_join(hs_url, 'static', '(.*)'),
-            StaticFileHandler,
-            {'path': os.path.join(os.path.dirname(__file__), 'static')}
-        ),
-        (url_path_join(web_app.settings['base_url'], 'hslogin'), HSLoginHandler),
-    ]
-    web_app.add_handlers('.*', handlers)
+    return [{"module": "nbfetch", "app": NbFetchApp}]

--- a/nbfetch/__init__.py
+++ b/nbfetch/__init__.py
@@ -1,6 +1,5 @@
 from .version import __version__
 from .handlers import HSLoginHandler, SyncHandler, HSyncHandler, UIHandler, HSHandler
-from .pull import GitPuller
 from notebook.utils import url_path_join
 from tornado.web import StaticFileHandler
 import os

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -401,6 +401,7 @@ class HSHandler(ExtensionHandler):
 
 
         if os.path.exists(pathid) and goto == 0 and overwrite == 0:
+            self.log.info("made it inside render confirm block")
             # overwrite or not? display modal dialog
             self.write(self.render_template("confirm.html", directory=pathid))
             self.flush()

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -411,7 +411,13 @@ class HSHandler(ExtensionHandler):
             return
 
         self.write(
-            self.render_template("hstatus.html", id=id, path=path, version=__version__)
+            self.render_template(
+                "hstatus.html",
+                id=id,
+                path=path,
+                version=__version__,
+                app_url=self.app_url,
+            )
         )
         self.flush()
 

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -26,7 +26,14 @@ from typing import Optional, Tuple
 class ExtensionHandler(
     ExtensionHandlerMixin, ExtensionHandlerJinjaMixin, JupyterHandler
 ):
-    pass
+    @property
+    def app_url(self) -> str:
+        """Base url joined to extension name.
+
+        If `jupyter_server.extension.application.ExtensionApp` not used to configure extension, it
+        is possible that `self.name` is "".
+        """
+        return urljoin(self.base_url, "{}/".format(self.name))
 
 
 class HSLoginHandler(ExtensionHandler):

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -17,10 +17,6 @@ from jupyter_server.extension.handler import (
     ExtensionHandlerJinjaMixin,
 )
 
-# JINJA2_ENV_KEY = "notebook_jinja2_env"
-# JINJA2_ENV_KEY = "nbclassic_jinja2_env"
-JINJA2_ENV_KEY = "jinja2_env"
-
 
 class ExtensionHandler(
     ExtensionHandlerMixin, ExtensionHandlerJinjaMixin, JupyterHandler

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -17,17 +17,26 @@ from jupyter_server.extension.handler import (
     ExtensionHandlerJinjaMixin,
 )
 
-JINJA2_ENV_KEY = "notebook_jinja2_env"
+# JINJA2_ENV_KEY = "notebook_jinja2_env"
+# JINJA2_ENV_KEY = "nbclassic_jinja2_env"
+JINJA2_ENV_KEY = "jinja2_env"
 
-class HSLoginHandler(IPythonHandler):
+
+class ExtensionHandler(
+    ExtensionHandlerMixin, ExtensionHandlerJinjaMixin, JupyterHandler
+):
+    pass
+
+
+class HSLoginHandler(ExtensionHandler):
     @gen.coroutine
     def get(self):
-        self.log.info('LOGIN GET' + self.request.uri)
+        self.log.info("LOGIN GET" + self.request.uri)
         params = {
-            "hslogin": urljoin(self.request.uri, 'hslogin'),
-            "image": urljoin(self.request.uri, 'hs-pull/static/hydroshare_logo.png'),
-            "error": self.get_argument("error",'Login Needed'),
-            "next": self.get_argument("next", "/")
+            "hslogin": urljoin(self.request.uri, "hslogin"),
+            "image": urljoin(self.request.uri, "hs-pull/static/hydroshare_logo.png"),
+            "error": self.get_argument("error", "Login Needed"),
+            "next": self.get_argument("next", "/"),
         }
         temp = self.render_template("hslogin.html", **params)
         self.write(temp)
@@ -36,36 +45,36 @@ class HSLoginHandler(IPythonHandler):
     def post(self):
         pwfile = os.path.expanduser("~/.hs_pass")
         userfile = os.path.expanduser("~/.hs_user")
-        with open(userfile, 'w') as f:
+        with open(userfile, "w") as f:
             f.write(self.get_argument("name"))
-        with open(pwfile, 'w') as f:
+        with open(pwfile, "w") as f:
             f.write(self.get_argument("pass"))
         self.redirect(url_unescape(self.get_argument("next", "/")))
 
 
-class SyncHandler(IPythonHandler):
+class SyncHandler(ExtensionHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # We use this lock to make sure that only one sync operation
         # can be happening at a time. Git doesn't like concurrent use!
-        if 'git_lock' not in self.settings:
-            self.settings['git_lock'] = locks.Lock()
+        if "git_lock" not in self.settings:
+            self.settings["git_lock"] = locks.Lock()
 
     @property
     def git_lock(self):
-        return self.settings['git_lock']
+        return self.settings["git_lock"]
 
     @gen.coroutine
     def emit(self, data):
         if type(data) is not str:
             serialized_data = json.dumps(data)
-            if 'output' in data:
-                self.log.info(data['output'].rstrip())
+            if "output" in data:
+                self.log.info(data["output"].rstrip())
         else:
             serialized_data = data
             self.log.info(data)
-        self.write('data: {}\n\n'.format(serialized_data))
+        self.write("data: {}\n\n".format(serialized_data))
         yield self.flush()
 
     @web.authenticated
@@ -74,24 +83,27 @@ class SyncHandler(IPythonHandler):
         try:
             yield self.git_lock.acquire(1)
         except gen.TimeoutError:
-            self.emit({
-                'phase': 'error',
-                'message': 'Another git operations is currently running, try again in a few minutes'
-            })
+            self.emit(
+                {
+                    "phase": "error",
+                    "message": "Another git operations is currently running, try again in a few minutes",
+                }
+            )
             return
 
         try:
-            repo = self.get_argument('repo')
-            branch = self.get_argument('branch')
-            repo_dir = repo.split('/')[-1]
+            repo = self.get_argument("repo")
+            branch = self.get_argument("branch")
+            repo_dir = repo.split("/")[-1]
 
             # We gonna send out event streams!
-            self.set_header('content-type', 'text/event-stream')
-            self.set_header('cache-control', 'no-cache')
+            self.set_header("content-type", "text/event-stream")
+            self.set_header("cache-control", "no-cache")
 
             gp = GitPuller(repo, branch, repo_dir)
 
             q = Queue()
+
             def pull():
                 try:
                     for line in gp.pull():
@@ -101,6 +113,7 @@ class SyncHandler(IPythonHandler):
                 except Exception as e:
                     q.put_nowait(e)
                     raise e
+
             self.gp_thread = threading.Thread(target=pull)
 
             self.gp_thread.start()
@@ -114,37 +127,45 @@ class SyncHandler(IPythonHandler):
                 if progress is None:
                     break
                 if isinstance(progress, Exception):
-                    self.emit({
-                        'phase': 'error',
-                        'message': str(progress),
-                        'output': '\n'.join([
-                            l.strip()
-                            for l in traceback.format_exception(
-                                type(progress), progress, progress.__traceback__
-                            )
-                        ])
-                    })
+                    self.emit(
+                        {
+                            "phase": "error",
+                            "message": str(progress),
+                            "output": "\n".join(
+                                [
+                                    l.strip()
+                                    for l in traceback.format_exception(
+                                        type(progress), progress, progress.__traceback__
+                                    )
+                                ]
+                            ),
+                        }
+                    )
                     return
 
-                self.emit({'output': progress, 'phase': 'syncing'})
+                self.emit({"output": progress, "phase": "syncing"})
 
-            self.emit({'phase': 'finished'})
+            self.emit({"phase": "finished"})
         except Exception as e:
-            self.emit({
-                'phase': 'error',
-                'message': str(e),
-                'output': '\n'.join([
-                    l.strip()
-                    for l in traceback.format_exception(
-                        type(e), e, e.__traceback__
-                    )
-                ])
-            })
+            self.emit(
+                {
+                    "phase": "error",
+                    "message": str(e),
+                    "output": "\n".join(
+                        [
+                            l.strip()
+                            for l in traceback.format_exception(
+                                type(e), e, e.__traceback__
+                            )
+                        ]
+                    ),
+                }
+            )
         finally:
             self.git_lock.release()
 
 
-class HSyncHandler(IPythonHandler):
+class HSyncHandler(ExtensionHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.log.info("HSyncHandler")
@@ -153,34 +174,33 @@ class HSyncHandler(IPythonHandler):
     def emit(self, data):
         if type(data) is not str:
             serialized_data = json.dumps(data)
-            if 'output' in data:
-                self.log.info(data['output'].rstrip())
+            if "output" in data:
+                self.log.info(data["output"].rstrip())
         else:
             serialized_data = data
             self.log.info(data)
-        self.write('data: {}\n\n'.format(serialized_data))
+        self.write("data: {}\n\n".format(serialized_data))
         yield self.flush()
-
 
     @gen.coroutine
     def post(self):
         print(self.get_argument("email"), self.get_argument("name"))
-        print('id=', self.get_argument('id'))
-
+        print("id=", self.get_argument("id"))
 
     # @web.authenticated
     @gen.coroutine
     def get(self):
         try:
-            id = self.get_argument('id')
+            id = self.get_argument("id")
 
             # We gonna send out event streams!
-            self.set_header('content-type', 'text/event-stream')
-            self.set_header('cache-control', 'no-cache')
+            self.set_header("content-type", "text/event-stream")
+            self.set_header("cache-control", "no-cache")
 
-            hs = HSPuller(id, self.settings['hydroshare'])
+            hs = HSPuller(id, self.settings["hydroshare"])
 
             q = Queue()
+
             def pull():
                 try:
                     for line in hs.pull():
@@ -190,6 +210,7 @@ class HSyncHandler(IPythonHandler):
                 except Exception as e:
                     q.put_nowait(e)
                     raise e
+
             self.hs_thread = threading.Thread(target=pull)
 
             self.hs_thread.start()
@@ -203,91 +224,87 @@ class HSyncHandler(IPythonHandler):
                 if progress is None:
                     break
                 if isinstance(progress, Exception):
-                    self.emit({
-                        'phase': 'error',
-                        'message': str(progress),
-                        'output': '\n'.join([
-                            l.strip()
-                            for l in traceback.format_exception(
-                                type(progress), progress, progress.__traceback__
-                            )
-                        ])
-                    })
+                    self.emit(
+                        {
+                            "phase": "error",
+                            "message": str(progress),
+                            "output": "\n".join(
+                                [
+                                    l.strip()
+                                    for l in traceback.format_exception(
+                                        type(progress), progress, progress.__traceback__
+                                    )
+                                ]
+                            ),
+                        }
+                    )
                     return
 
-                self.emit({'output': progress, 'phase': 'syncing'})
+                self.emit({"output": progress, "phase": "syncing"})
 
-            self.emit({'phase': 'finished'})
+            self.emit({"phase": "finished"})
         except Exception as e:
-            self.emit({
-                'phase': 'error',
-                'message': str(e),
-                'output': '\n'.join([
-                    l.strip()
-                    for l in traceback.format_exception(
-                        type(e), e, e.__traceback__
-                    )
-                ])
-            })
-
-
-class UIHandler(IPythonHandler):
-    def initialize(self):
-        super().initialize()
-        # FIXME: Is this really the best way to use jinja2 here?
-        # I can't seem to get the jinja2 env in the base handler to
-        # actually load templates from arbitrary paths ugh.
-        jinja2_env = self.settings[JINJA2_ENV_KEY]
-        jinja2_env.loader = jinja2.ChoiceLoader([
-            jinja2_env.loader,
-            jinja2.FileSystemLoader(
-                os.path.join(os.path.dirname(__file__), 'templates')
+            self.emit(
+                {
+                    "phase": "error",
+                    "message": str(e),
+                    "output": "\n".join(
+                        [
+                            l.strip()
+                            for l in traceback.format_exception(
+                                type(e), e, e.__traceback__
+                            )
+                        ]
+                    ),
+                }
             )
-        ])
 
+
+class UIHandler(ExtensionHandler):
     @web.authenticated
     @gen.coroutine
     def get(self):
-        app_env = os.getenv('NBGITPULLER_APP', default='notebook')
+        app_env = os.getenv("NBGITPULLER_APP", default="notebook")
 
-        repo = self.get_argument('repo')
-        branch = self.get_argument('branch', 'master')
-        urlPath = self.get_argument('urlpath', None) or \
-                  self.get_argument('urlPath', None)
-        subPath = self.get_argument('subpath', None) or \
-                  self.get_argument('subPath', '.')
-        app = self.get_argument('app', app_env)
+        repo = self.get_argument("repo")
+        branch = self.get_argument("branch", "master")
+        urlPath = self.get_argument("urlpath", None) or self.get_argument(
+            "urlPath", None
+        )
+        subPath = self.get_argument("subpath", None) or self.get_argument(
+            "subPath", "."
+        )
+        app = self.get_argument("app", app_env)
 
         if urlPath:
             path = urlPath
         else:
-            repo_dir = repo.split('/')[-1]
+            repo_dir = repo.split("/")[-1]
             path = os.path.join(repo_dir, subPath)
-            if app.lower() == 'lab':
-                path = 'lab/tree/' + path
-            elif path.lower().endswith('.ipynb'):
-                path = 'notebooks/' + path
+            if app.lower() == "lab":
+                path = "lab/tree/" + path
+            elif path.lower().endswith(".ipynb"):
+                path = "notebooks/" + path
             else:
-                path = 'tree/' + path
+                path = "tree/" + path
 
         self.write(
             self.render_template(
-                'status.html',
-                repo=repo, branch=branch, path=path, version=__version__
-            ))
+                "status.html", repo=repo, branch=branch, path=path, version=__version__
+            )
+        )
         self.flush()
 
-class HSHandler(ExtensionHandler):
 
+class HSHandler(ExtensionHandler):
     def check_auth(self, auth):
         hs = HydroShare(auth=auth)
-        self.log.info('hs=%s' % str(hs))
-
+        self.log.info("hs=%s" % str(hs))
 
         try:
             info = hs.getUserInfo()
-            self.settings['hydroshare'] = hs
-            self.log.info('info=%s' % info)
+            self.settings["hydroshare"] = hs
+            self.log.info("info=%s" % info)
         except:
             hs = None
         return hs
@@ -298,18 +315,20 @@ class HSHandler(ExtensionHandler):
         # check for oauth
         authfile = os.path.expanduser("~/.hs_auth")
         try:
-            with open(authfile, 'rb') as f:
+            with open(authfile, "rb") as f:
                 token, cid = pickle.load(f)
-            auth = HydroShareAuthOAuth2(cid, '', token=token)
-            self.log.info('auth=%s' % str(auth))
+            auth = HydroShareAuthOAuth2(cid, "", token=token)
+            self.log.info("auth=%s" % str(auth))
 
             hs = self.check_auth(auth)
-            self.log.info('hs=%s' % str(hs))
+            self.log.info("hs=%s" % str(hs))
 
             if hs is None:
-                message = url_escape("Oauth Login Failed.  Login with username and password or logout from JupyterHub and reauthenticate with Hydroshare.")
+                message = url_escape(
+                    "Oauth Login Failed.  Login with username and password or logout from JupyterHub and reauthenticate with Hydroshare."
+                )
         except:
-            message = ''
+            message = ""
 
         if hs is None:
             # If oauth fails, we can log in using
@@ -328,13 +347,14 @@ class HSHandler(ExtensionHandler):
                 if hs is None:
                     message = url_escape("Login Failed. Please Try again")
             except:
-                message = url_escape("You need to provide login credentials to access HydroShare Resources.")
+                message = url_escape(
+                    "You need to provide login credentials to access HydroShare Resources."
+                )
 
         if hs is None:
             _next = url_escape(url_escape(self.request.uri))
-            upath = urljoin(self.request.uri, 'hslogin')
-            self.redirect('%s?error=%s&next=%s' % (upath, message, _next))
-
+            upath = urljoin(self.request.uri, "hslogin")
+            self.redirect("%s?error=%s&next=%s" % (upath, message, _next))
 
     @web.authenticated
     @gen.coroutine
@@ -345,52 +365,50 @@ class HSHandler(ExtensionHandler):
         start - notebook to launch (optional)
         app - Optinal. 'lab' will try to run jupyter lab
         overwrite - Overwrite any existing local copy or the resource
-        goto - Do not overwrite.  Just go to the resouce 
+        goto - Do not overwrite.  Just go to the resouce
         """
 
-        app_env = 'notebook'
-        self.log.info('HS GET ' + str(self.request.uri))
+        app_env = "notebook"
+        self.log.info("HS GET " + str(self.request.uri))
 
         self.login()
 
-        id = self.get_argument('id')
-        start = self.get_argument('start', '')
-        app = self.get_argument('app', app_env)
-        overwrite = self.get_argument('overwrite', 0)
-        goto = self.get_argument('goto', 0)
+        id = self.get_argument("id")
+        start = self.get_argument("start", "")
+        app = self.get_argument("app", app_env)
+        overwrite = self.get_argument("overwrite", 0)
+        goto = self.get_argument("goto", 0)
 
-        self.log.info('GET %s %s %s %s %s' % (id , start, app, overwrite, goto))
+        self.log.info("GET %s %s %s %s %s" % (id, start, app, overwrite, goto))
 
         # create Downloads directory if necessary
-        download_dir = os.environ.get('JUPYTER_DOWNLOADS', 'Downloads')
+        download_dir = os.environ.get("JUPYTER_DOWNLOADS", "Downloads")
         if not os.path.isdir(download_dir):
             os.makedirs(download_dir)
 
-        nbdir = os.environ.get('NOTEBOOK_HOME')
+        nbdir = os.environ.get("NOTEBOOK_HOME")
         relative_download_dir = os.path.relpath(download_dir, nbdir)
         pathid = os.path.join(relative_download_dir, id)
         if os.path.exists(pathid) and goto == 0 and overwrite == 0:
             # overwrite or not? display modal dialog
-            self.write(self.render_template('confirm.html', directory=pathid))
+            self.write(self.render_template("confirm.html", directory=pathid))
             self.flush()
             return
 
-        path = os.path.join(pathid, id, 'data', 'contents', start)
-        if app.lower() == 'lab':
-            path = 'lab/tree/' + path
-        elif path.lower().endswith('.ipynb'):
-            path = 'notebooks/' + path
+        path = os.path.join(pathid, id, "data", "contents", start)
+        if app.lower() == "lab":
+            path = "lab/tree/" + path
+        elif path.lower().endswith(".ipynb"):
+            path = "notebooks/" + path
         else:
-            path = 'tree/' + path
+            path = "tree/" + path
 
-        self.log.info('path=%s' % path)
+        self.log.info("path=%s" % path)
         if goto:
             self.redirect(path)
             return
 
         self.write(
-            self.render_template(
-                'hstatus.html',
-                id=id, path=path, version=__version__
-            ))
+            self.render_template("hstatus.html", id=id, path=path, version=__version__)
+        )
         self.flush()

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -335,7 +335,7 @@ class HSHandler(ExtensionHandler):
             # If oauth fails, we can log in using
             # user name and password.  These are saved in
             # files in the home directory.
-            username, password = _get_user_auth()
+            username, password = _get_user_authentication()
             try:
                 auth = HydroShareAuthBasic(username=username, password=password)
                 hs = self.check_auth(auth)
@@ -409,7 +409,7 @@ class HSHandler(ExtensionHandler):
         self.flush()
 
 
-def _get_user_auth() -> Tuple[Optional[str], Optional[str]]:
+def _get_user_authentication() -> Tuple[Optional[str], Optional[str]]:
     """retrieve HS authentication from standard locations(see below) as tuple of username and
     password. If either cannot be located, both tuple members are be None.
 

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -389,19 +389,11 @@ class HSHandler(ExtensionHandler):
             os.makedirs(download_dir)
 
         nbdir = os.environ.get("NOTEBOOK_HOME")
-        # remove soon
-        self.log.info(f"{download_dir=}")
-        self.log.info(f"{nbdir=}")
-        self.log.info(f"{goto=}")
-        self.log.info(f"{overwrite=}")
         relative_download_dir = os.path.relpath(download_dir, nbdir)
         pathid = os.path.join(relative_download_dir, id)
-        # remove soon
-        self.log.info(f"{pathid=}")
 
         abs_pathid = os.path.join(download_dir, id)
         if os.path.exists(abs_pathid) and goto == 0 and overwrite == 0:
-            self.log.info("made it inside render confirm block")
             # overwrite or not? display modal dialog
             self.write(self.render_template("confirm.html", directory=pathid))
             self.flush()

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -399,8 +399,8 @@ class HSHandler(ExtensionHandler):
         # remove soon
         self.log.info(f"{pathid=}")
 
-
-        if os.path.exists(pathid) and goto == 0 and overwrite == 0:
+        abs_pathid = os.path.join(download_dir, id)
+        if os.path.exists(abs_pathid) and goto == 0 and overwrite == 0:
             self.log.info("made it inside render confirm block")
             # overwrite or not? display modal dialog
             self.write(self.render_template("confirm.html", directory=pathid))

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -7,7 +7,6 @@ import threading
 import json
 import os
 from pathlib import Path
-import io
 from queue import Queue, Empty
 from hs_restclient import HydroShare, HydroShareAuthBasic, HydroShareAuthOAuth2
 from .pull import GitPuller, HSPuller

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -335,14 +335,8 @@ class HSHandler(ExtensionHandler):
             # If oauth fails, we can log in using
             # user name and password.  These are saved in
             # files in the home directory.
-            pwfile = os.path.expanduser("~/.hs_pass")
-            userfile = os.path.expanduser("~/.hs_user")
-
+            username, password = _get_user_auth()
             try:
-                with open(userfile) as f:
-                    username = f.read().strip()
-                with open(pwfile) as f:
-                    password = f.read().strip()
                 auth = HydroShareAuthBasic(username=username, password=password)
                 hs = self.check_auth(auth)
                 if hs is None:

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -407,6 +407,7 @@ class HSHandler(ExtensionHandler):
 
         self.log.info("path=%s" % path)
         if goto:
+            path = urljoin(self.base_url, path)
             self.redirect(path)
             return
 

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -11,6 +11,11 @@ from hs_restclient import HydroShare, HydroShareAuthBasic, HydroShareAuthOAuth2
 from .pull import GitPuller, HSPuller
 from .version import __version__
 import pickle
+from jupyter_server.base.handlers import JupyterHandler
+from jupyter_server.extension.handler import (
+    ExtensionHandlerMixin,
+    ExtensionHandlerJinjaMixin,
+)
 
 JINJA2_ENV_KEY = "notebook_jinja2_env"
 
@@ -272,16 +277,7 @@ class UIHandler(IPythonHandler):
             ))
         self.flush()
 
-class HSHandler(IPythonHandler):
-    def initialize(self):
-        super().initialize()
-        jinja2_env = self.settings[JINJA2_ENV_KEY]
-        jinja2_env.loader = jinja2.ChoiceLoader([
-            jinja2_env.loader,
-            jinja2.FileSystemLoader(
-                os.path.join(os.path.dirname(__file__), 'templates')
-            )
-        ])
+class HSHandler(ExtensionHandler):
 
     def check_auth(self, auth):
         hs = HydroShare(auth=auth)

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -389,8 +389,17 @@ class HSHandler(ExtensionHandler):
             os.makedirs(download_dir)
 
         nbdir = os.environ.get("NOTEBOOK_HOME")
+        # remove soon
+        self.log.info(f"{download_dir=}")
+        self.log.info(f"{nbdir=}")
+        self.log.info(f"{goto=}")
+        self.log.info(f"{overwrite=}")
         relative_download_dir = os.path.relpath(download_dir, nbdir)
         pathid = os.path.join(relative_download_dir, id)
+        # remove soon
+        self.log.info(f"{pathid=}")
+
+
         if os.path.exists(pathid) and goto == 0 and overwrite == 0:
             # overwrite or not? display modal dialog
             self.write(self.render_template("confirm.html", directory=pathid))

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -2,16 +2,14 @@ from tornado import gen, web, locks
 from tornado.escape import url_escape, url_unescape
 import traceback
 from urllib.parse import urljoin
-from notebook.base.handlers import IPythonHandler
+
 import threading
 import json
 import os
 from queue import Queue, Empty
-import jinja2
 from hs_restclient import HydroShare, HydroShareAuthBasic, HydroShareAuthOAuth2
 from .pull import GitPuller, HSPuller
 from .version import __version__
-from notebook.utils import url_path_join
 import pickle
 
 JINJA2_ENV_KEY = "notebook_jinja2_env"

--- a/nbfetch/static/hindex.js
+++ b/nbfetch/static/hindex.js
@@ -12,12 +12,12 @@ require([
 
     Terminal.applyAddon(fit);
 
-    function GitSync(baseUrl, id, path) {
+    function GitSync(baseUrl, appUrl, id, path) {
         console.log("HINDEX GitSync");
         // Class that talks to the API backend & emits events as appropriate
-        this.baseUrl = baseUrl;
+        this.appUrl = appUrl;
         this.id = id;
-        this.redirectUrl = baseUrl + path;
+        this.redirectUrl =  baseUrl + path;
         this.callbacks = {};
     }
 
@@ -40,7 +40,7 @@ require([
     GitSync.prototype.start = function() {
         console.log('START');
         // Start git pulling handled by SyncHandler, declared in handlers.py
-        var syncUrl = this.baseUrl + 'hs-pull/api?' + $.param({
+        var syncUrl = this.appUrl + 'hs-pull/api?' + $.param({
             id: this.id
         });
 
@@ -120,6 +120,7 @@ require([
 
     var gs = new GitSync(
         utils.get_body_data('baseUrl'),
+        utils.get_body_data('appUrl'),
         utils.get_body_data('id'),
         utils.get_body_data('path')
     );

--- a/nbfetch/templates/confirm.html
+++ b/nbfetch/templates/confirm.html
@@ -13,6 +13,11 @@
 
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <style>
+      .word-wrap {
+        word-wrap: break-word;
+      }
+    </style>
 
   </head>
   <body>
@@ -23,7 +28,7 @@
         <div class="modal-header">
           <h5 class="modal-title" id="confirmModalLabel">Directory Exists</h5>
         </div>
-        <div class="modal-body">
+        <div class="modal-body word-wrap">
           Directory "{{directory}}" already exists on JupyterHub.
           <br><br>
           Do you want to overwrite the current contents, replacing it with files from HydroShare?

--- a/nbfetch/templates/hstatus.html
+++ b/nbfetch/templates/hstatus.html
@@ -3,6 +3,7 @@
 {% block params %}
 {{super()}}
 data-base-url="{{ base_url | urlencode }}"
+data-app-url="{{ app_url | urlencode }}"
 data-id="{{ id | urlencode }}"
 data-path="{{ path | urlencode }}"
 {% endblock %}

--- a/nbfetch/templates/hstatus.html
+++ b/nbfetch/templates/hstatus.html
@@ -32,7 +32,7 @@ data-path="{{ path | urlencode }}"
 
 {% block script %}
 {{super()}}
-<script src="{{ base_url }}hs-pull/static/hindex.js?v={{ version }}">
+<script src="{{ static_url("hindex.js") }}">
 </script>
 {% endblock %}
 

--- a/nbfetch/version.py
+++ b/nbfetch/version.py
@@ -1,2 +1,2 @@
 """"The nbfetch PyPI package SemVer version."""
-__version__ = '0.0.4'
+__version__ = '0.0.5'

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     platforms="any",
-    install_requires=["notebook>=5.5.0", "tornado", "hs_restclient"],
+    install_requires=["notebook>=5.5.0", "tornado", "hs_restclient", "jupyter_server"],
+    extras_require={"develop": ["pytest", "pytest-jupyter"]},
     data_files=[
         (
             "etc/jupyter/jupyter_server_config.d",

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,18 @@ setup(
     license="3-clause BSD",
     author="Peter Veerman, YuviPanda",
     author_email="peterkangveerman@gmail.com",
+    maintainer="Austin Raney",
+    maintainer_email="araney@cuahsi.org",
     description="Notebook Extension to do one-way synchronization of git repositories",
     packages=find_packages(),
     include_package_data=True,
     platforms="any",
     install_requires=["notebook>=5.5.0", "tornado", "hs_restclient"],
     data_files=[
-        ("etc/jupyter/jupyter_notebook_config.d", ["nbfetch/etc/nbfetch.json"])
+        (
+            "etc/jupyter/jupyter_server_config.d",
+            ["jupyter-config/jupyter_server_config.d/nbfetch.json"],
+        ),
     ],
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
[This](https://github.com/jupyter/nbclassic/pull/130) upstream change to `nbclassic` seems to have changed the settings dict key for the handler's `jinja2` environment  (related to #3) from `notebook_jinja2_env` to `nbfetch_jinja2_env`. This change has been confirmed to affect `nbfetch` with `nbclassic==0.4.3`, did not test previous versions. Last known working version is `nbclassic==0.3.4`. To avoid this problem in the future, this PR ports `nbfetch` from a [classic notebook server extension](https://jupyter-notebook.readthedocs.io/en/stable/extending/handlers.html) to a [jupyter server extension](https://jupyter-server.readthedocs.io/en/latest/developers/extensions.html). The jupyter server project is better documented and is advised way to develop new server extensions. With that in mind, will this break things? 

> If you’re a developer of a [classic Notebook Server](https://jupyter-notebook.readthedocs.io/en/stable/extending/handlers.html) extension, your extension should be able to work with both the classic notebook server and jupyter_server.

[source](https://jupyter-server.readthedocs.io/en/latest/developers/extensions.html#migrating-an-extension-to-use-jupyter-server)

It seems that this will be a backwards compatible change. However, the installation process will change slightly if merged, so in that sense, this **is** a breaking change. If we do merge, we should ping everyone we know who uses `nbfetch` so they are aware.

## Additions

- provide HS authentication via `HS_USER` and `HS_PASS` environment variables. `~/.hs_user` and `~/.hs_pass` still function and are given precedence. 

## Changes

- BREAKING CHANGE:`nbfetch` base url is now `/nbfetch/` previously was `/`
- `nbfetch` is now a jupyter server extension. See readme for new installation instructions
- css fix: resource overwrite confirmation page now correctly word-wraps long path names

### Future Todos:

- Move logic for creating `downloads` directory outside of `handlers::HSHandler::get`
- Service should fail if `downloads` directory is not child of `NOTEBOOK_HOME` env var. This assumption is not checked in `handlers::HSHandler::get` 
- Add unit tests to hopefully act on PRs like this earlier in the future
- Refactor string formatting to use f-strings instead of % interpolated