### PR TITLE
Allow pulling public resources without HS authentication

### DIFF
--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -45,6 +45,7 @@ class HSLoginHandler(ExtensionHandler):
             "image": urljoin(self.request.uri, "hs-pull/static/hydroshare_logo.png"),
             "error": self.get_argument("error", "Login Needed"),
             "next": self.get_argument("next", "/"),
+            "xsrf_token": self.xsrf_token,
         }
         temp = self.render_template("hslogin.html", **params)
         self.write(temp)

--- a/nbfetch/handlers.py
+++ b/nbfetch/handlers.py
@@ -373,9 +373,20 @@ class HSHandler(ExtensionHandler):
         app_env = "notebook"
         self.log.info("HS GET " + str(self.request.uri))
 
-        self.login()
-
         id = self.get_argument("id")
+
+        # check to see if the resource is public
+        hs = HydroShare()
+        try:
+            hs.resource(id)
+            self.log.info(f"Pulling public rid {id}. \
+                          hsclient will remain unauthenticated")
+            self.settings["hydroshare"] = hs
+        except Exception as e:
+            self.log.info(f"Unauthenticated pull for private rid {id} \
+                           failed: {e}")
+            self.login()
+
         start = self.get_argument("start", "")
         app = self.get_argument("app", app_env)
         overwrite = self.get_argument("overwrite", 0)

--- a/nbfetch/templates/hslogin.html
+++ b/nbfetch/templates/hslogin.html
@@ -47,6 +47,7 @@ button:hover {
     <input type="password" placeholder="Enter Password" name="pass" required>
     <button type="submit">Login</button>
   </div>
+  <input type="hidden" name="_xsrf" value="{{ xsrf_token }}">
 </form>
 </body>
 </html>


### PR DESCRIPTION
Resolves #12 by allowing nbfetch to fetch public HydroShare resources without authenticating
Resolves https://github.com/hydroshare/nbfetch/issues/13 by adding xsrf token in the hydroshare auth template