### PR TITLE
Remove notebook dependency

### DIFF
--- a/nbfetch/__init__.py
+++ b/nbfetch/__init__.py
@@ -1,13 +1,13 @@
 from .version import __version__
 from .handlers import HSLoginHandler, SyncHandler, HSyncHandler, UIHandler, HSHandler
-from notebook.utils import url_path_join
+from jupyter_server.utils import url_path_join
 from tornado.web import StaticFileHandler
 import os
 
 import jupyter_server
 from jupyter_server.extension.application import ExtensionApp
-from notebook import DEFAULT_TEMPLATE_PATH_LIST
-from notebook.notebookapp import DEFAULT_STATIC_FILES_PATH
+from jupyter_server import DEFAULT_TEMPLATE_PATH_LIST
+from jupyter_server import DEFAULT_STATIC_FILES_PATH
 import jinja2
 import gettext
 

--- a/nbfetch/__init__.py
+++ b/nbfetch/__init__.py
@@ -6,7 +6,8 @@ import os
 
 import jupyter_server
 from jupyter_server.extension.application import ExtensionApp
-from notebook import DEFAULT_STATIC_FILES_PATH, DEFAULT_TEMPLATE_PATH_LIST
+from notebook import DEFAULT_TEMPLATE_PATH_LIST
+from notebook.notebookapp import DEFAULT_STATIC_FILES_PATH
 import jinja2
 import gettext
 
@@ -21,6 +22,8 @@ class NbFetchApp(ExtensionApp):
     load_other_extensions = True
     file_url_prefix = "/"
 
+    # Default static files path changed in 6.5.0:
+    # https://github.com/jupyter/notebook/releases/tag/v6.5.0
     # Local path to static files directory.
     static_paths = [
         os.path.join(HERE, "static"),

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     platforms="any",
-    install_requires=["tornado", "hsclient>=1.1.0", "jupyter_server"],
+    install_requires=["tornado", "hsclient>=1.1.0", "jupyter_server", "setuptools"],
     extras_require={"develop": ["pytest", "pytest-jupyter"]},
     data_files=[
         (

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     platforms="any",
-    install_requires=["tornado", "hsclient", "jupyter_server"],
+    install_requires=["tornado", "hsclient>=1.1.0", "jupyter_server"],
     extras_require={"develop": ["pytest", "pytest-jupyter"]},
     data_files=[
         (

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     platforms="any",
-    install_requires=["notebook==6.4.6", "tornado", "hsclient", "jupyter_server"],
+    install_requires=["notebook==6.5.4", "tornado", "hsclient", "jupyter_server"],
     extras_require={"develop": ["pytest", "pytest-jupyter"]},
     data_files=[
         (

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     platforms="any",
-    install_requires=["notebook==6.5.4", "tornado", "hsclient", "jupyter_server"],
+    install_requires=["tornado", "hsclient", "jupyter_server"],
     extras_require={"develop": ["pytest", "pytest-jupyter"]},
     data_files=[
         (


### PR DESCRIPTION
Upgrading notebook version in hopes it resolves dependency tree for `hydroshare_on_jupyter`

Trouble going to >[6.5.5](https://github.com/jupyter/notebook/releases/tag/v6.5.5) but <7.x  -- these newer versions seem to have pyzmq pinned <v25 which is not compatible with the other packages in the extension it looks like